### PR TITLE
change theta2 definition

### DIFF
--- a/base_simulation_script.R
+++ b/base_simulation_script.R
@@ -66,6 +66,7 @@ itemid_yr1 <- responses_yr1[, "itemid"]
 itemid_yr2 <- responses_yr2[, "itemid"]
 response_yr1 <- responses_yr1[, "response"]
 response_yr2 <- responses_yr2[, "response"]
+per_group <- people[, "groupid"]
   
 n_people <- N_people
 n_groups <- N_groups
@@ -76,7 +77,7 @@ n_items <- nrow(items_yr1) + nrow(items_yr2) - anchor_length
 
 b.dat_long <- list("n_people", "n_items", "n_observations", "n_groups", 
                    "studentid", "groupid", "itemid", 
-                   "response_yr1", "response_yr2")
+                   "response_yr1", "response_yr2", "per_group")
 
 
 precomp <- stanc(model_code = stancode_long)
@@ -84,7 +85,7 @@ precomp_model <- stan_model(stanc_ret = precomp)
 
 #conducting the analysis
 analysis <- sampling(precomp_model, data = b.dat_long,
-                     iter = 10000, warmup = 5000, chains = 2, verbose = FALSE, 
+                     iter = 1000, warmup = 500, chains = 2, verbose = FALSE, 
                      cores = 2)
 
 saveRDS(analysis, "group_aberrance_IRT_test.rds")

--- a/stan_script.R
+++ b/stan_script.R
@@ -10,6 +10,7 @@ data {
   int<lower=0, upper=1> response_yr1[n_observations];
   int<lower=0, upper=1> response_yr2[n_observations];
   int<lower=0, upper=n_groups> groupid[n_observations];
+  int<lower=1, upper=n_groups> per_group[n_people];
 }
 
 parameters {
@@ -30,12 +31,11 @@ transformed parameters {
   real theta2[n_people];
   real mu2;
   
-  for (i in 1:n_observations) {
-    theta2[studentid[i]] = corr*theta1[studentid[i]] + group_inc[groupid[i]] + indiv_err[studentid[i]];
+  for (i in 1:n_people) {
+    theta2[i] = corr*theta1[i] + group_inc[per_group[i]] + indiv_err[i];
   }
 
   mu2 = mean(theta2);
-
 }
 
 model {
@@ -44,8 +44,8 @@ model {
   
   a ~ lognormal(0, 1);
   b ~ normal(0, 1);
-//  a_yr2 ~ lognormal(0, 1);
-//  b_yr2 ~ normal(0, 1);
+  //  a_yr2 ~ lognormal(0, 1);
+  //  b_yr2 ~ normal(0, 1);
   theta1 ~ normal(0, 1);
   corr ~ normal(0, 1);
   group_inc ~ normal(0, 3);


### PR DESCRIPTION
I changed the definition of theta2 so that it just has to loop over the number of people instead of all the observations. Not sure if it'll make things significantly faster, but worth a try. Not sure how fast things are running now, but on my mac gradient evaluation takes about 0.12 seconds.